### PR TITLE
Look also for build/compile_commands.json as a project root

### DIFF
--- a/cquery.el
+++ b/cquery.el
@@ -96,7 +96,7 @@ in a subproject and thus does not belong to the current workspace.
   :group 'cquery)
 
 (defcustom cquery-project-root-matchers
-  '(cquery-project-roots-matcher projectile-project-root "compile_commands.json" ".cquery")
+  '(cquery-project-roots-matcher projectile-project-root "compile_commands.json" ".cquery" "build/compile_commands.json")
   "List of matchers that are used to locate the cquery project roots.
 Each matcher is run in order, and the first successful (non-nil) matcher
 determines the project root.


### PR DESCRIPTION
cquery will (by default) look for this so it makes sense for the Emacs
client to do so.