### PR TITLE
Repair missing workspace in call/inheritance hierarchy

### DIFF
--- a/cquery-call-hierarchy.el
+++ b/cquery-call-hierarchy.el
@@ -118,21 +118,22 @@
 
 (defun cquery-call-hierarchy (callee)
   (interactive "P")
-  (cquery--cquery-buffer-check)
-  (setq callee (if callee t :json-false))
-  (cquery-tree--open
-   (make-cquery-tree-client
-    :name "call hierarchy"
-    :mode-line-format (format " %s %s %s %s"
-                              (propertize (if (eq callee t) "Callee types:" "Caller types:") 'face 'cquery-tree-mode-line-face)
-                              (propertize "Normal" 'face 'cquery-call-hierarchy-node-normal-face)
-                              (propertize "Base" 'face 'cquery-call-hierarchy-node-base-face)
-                              (propertize "Derived" 'face 'cquery-call-hierarchy-node-derived-face))
-    :top-line-f (lambda () (propertize (if (eq callee t) "Callees of " "Callers of") 'face 'cquery-tree-mode-line-face))
-    :make-string-f 'cquery-call-hierarchy--make-string
-    :read-node-f 'cquery-call-hierarchy--read-node
-    :request-children-f (apply-partially #'cquery-call-hierarchy--request-children callee)
-    :request-init-f (lambda () (cquery-call-hierarchy--request-init callee)))))
+  (when-lsp-workspace (cquery--get-lsp-workspace)
+    (cquery--cquery-buffer-check)
+    (setq callee (if callee t :json-false))
+    (cquery-tree--open
+     (make-cquery-tree-client
+      :name "call hierarchy"
+      :mode-line-format (format " %s %s %s %s"
+                                (propertize (if (eq callee t) "Callee types:" "Caller types:") 'face 'cquery-tree-mode-line-face)
+                                (propertize "Normal" 'face 'cquery-call-hierarchy-node-normal-face)
+                                (propertize "Base" 'face 'cquery-call-hierarchy-node-base-face)
+                                (propertize "Derived" 'face 'cquery-call-hierarchy-node-derived-face))
+      :top-line-f (lambda () (propertize (if (eq callee t) "Callees of " "Callers of") 'face 'cquery-tree-mode-line-face))
+      :make-string-f 'cquery-call-hierarchy--make-string
+      :read-node-f 'cquery-call-hierarchy--read-node
+      :request-children-f (apply-partially #'cquery-call-hierarchy--request-children callee)
+      :request-init-f (lambda () (cquery-call-hierarchy--request-init callee))))))
 
 (provide 'cquery-call-hierarchy)
 ;;; cquery-call-hierarchy.el ends here

--- a/cquery-common.el
+++ b/cquery-common.el
@@ -91,6 +91,11 @@
   "Render a string as a type"
   (string-remove-suffix " a;" (cquery--render-string (format "%s a;" str))))
 
+(defun cquery--get-lsp-workspace ()
+  "Return cquery workspace for current buffer or nil"
+  (find-if '(lambda (ws) (equal 'cquery (lsp--client-server-id (lsp--workspace-client ws))))
+           lsp--buffer-workspaces))
+
 ;; ---------------------------------------------------------------------
 ;;   Commands
 ;; ---------------------------------------------------------------------

--- a/cquery-inheritance-hierarchy.el
+++ b/cquery-inheritance-hierarchy.el
@@ -98,20 +98,21 @@
 
 (defun cquery-inheritance-hierarchy (derived)
   (interactive "P")
-  (cquery--cquery-buffer-check)
-  (let ((json-derived (if derived t :json-false)))
-    (cquery-tree--open
-     (make-cquery-tree-client
-      :name "inheritance hierarchy"
-      :mode-line-format (propertize (if derived
-                                        "Inheritance Hierarchy: Subclasses"
-                                      "Inheritance Hierarchy: Bases")
-                                    'face 'cquery-tree-mode-line-face)
-      :top-line-f (lambda () (propertize (if derived "Derive from" "Bases of") 'face 'cquery-tree-mode-line-face))
-      :make-string-f 'cquery-inheritance-hierarchy--make-string
-      :read-node-f 'cquery-inheritance-hierarchy--read-node
-      :request-children-f (apply-partially #'cquery-inheritance-hierarchy--request-children json-derived)
-      :request-init-f (lambda () (cquery-inheritance-hierarchy--request-init json-derived))))))
+  (when-lsp-workspace (cquery--get-lsp-workspace)
+    (cquery--cquery-buffer-check)
+    (let ((json-derived (if derived t :json-false)))
+      (cquery-tree--open
+       (make-cquery-tree-client
+        :name "inheritance hierarchy"
+        :mode-line-format (propertize (if derived
+                                          "Inheritance Hierarchy: Subclasses"
+                                        "Inheritance Hierarchy: Bases")
+                                      'face 'cquery-tree-mode-line-face)
+        :top-line-f (lambda () (propertize (if derived "Derive from" "Bases of") 'face 'cquery-tree-mode-line-face))
+        :make-string-f 'cquery-inheritance-hierarchy--make-string
+        :read-node-f 'cquery-inheritance-hierarchy--read-node
+        :request-children-f (apply-partially #'cquery-inheritance-hierarchy--request-children json-derived)
+        :request-init-f (lambda () (cquery-inheritance-hierarchy--request-init json-derived)))))))
 
 (provide 'cquery-inheritance-hierarchy)
 ;;; cquery-inheritance-hierarchy.el ends here


### PR DESCRIPTION
With new multi workspace lsp-mode there is no single current workspace
associated with a buffer anymore. This leads to "Cquery is not enabled
in this buffer." errors in cquery-call-hierarchy and
cquery-inheritance-hierarchy.

Fix by adding a new utility function cquery--get-lsp-workspace to get
the current cquery workspace from the list of buffer workspaces and
apply during the affected calls.