### PR TITLE
Adapt type rendering to new lsp

### DIFF
--- a/cquery-common.el
+++ b/cquery-common.el
@@ -74,18 +74,8 @@
   (inline-quote (cl-assert (cquery--is-cquery-buffer) nil
                            "Cquery is not enabled in this buffer.")))
 
-(defun cquery--get-renderer ()
-  (thread-last lsp--cur-workspace
-    lsp--workspace-client
-    lsp--client-string-renderers
-    (assoc-string (thread-first lsp--cur-workspace
-                    lsp--workspace-client
-                    lsp--client-language-id
-                    (funcall (current-buffer))))
-    cdr))
-
 (defun cquery--render-string (str)
-  (funcall (cquery--get-renderer) str))
+  (funcall (lsp-get-renderer "cpp") str))
 
 (defun cquery--render-type (str)
   "Render a string as a type"


### PR DESCRIPTION
lsp--client-string-renderers seems to be unsupported and should, as
indicated by code comment, be removed in the future. Currently it is
nil, preventing string rendering for
e.g. cquery-inheritance-hierarchy.

Use available simpler typed string rendering interface by lsp assuming
correct language is always cpp.