### PR TITLE
Repair cquery cache directory location

### DIFF
--- a/cquery.el
+++ b/cquery.el
@@ -218,7 +218,7 @@ The place is given by cquery-cache-dir-consolidated-path."
 (defun cquery--get-init-params ()
   `(,@cquery-extra-init-params
     :cacheDirectory ,(file-name-as-directory
-                      (funcall cquery-cache-dir-function default-directory))
+                      (funcall cquery-cache-dir-function (lsp--suggest-project-root)))
     :highlight (:enabled ,(or (and cquery-sem-highlight-method t) :json-false))
     :emitInactiveRegions ,(or cquery-enable-inactive-region :json-false)))
 


### PR DESCRIPTION
Use lsp to suggest project root instead of using default-directory,
i.e. the directory of the first buffer open with cquery during an
emacs session.

This restores the behavior documented for 'cquery-cache-dir'.