### PR TITLE
Fix cquery buffer check for newer lsp-mode

### DIFF
--- a/cquery-common.el
+++ b/cquery-common.el
@@ -68,7 +68,7 @@
   "Return non-nil if current buffer is using the cquery client"
   (with-current-buffer (or buffer (current-buffer))
     (and lsp--cur-workspace
-         (eq (lsp--client-get-root (lsp--workspace-client lsp--cur-workspace)) 'cquery--get-root))))
+         (equal (lsp--workspace-root lsp--cur-workspace) (cquery--get-root)))))
 
 (define-inline cquery--cquery-buffer-check ()
   (inline-quote (cl-assert (cquery--is-cquery-buffer) nil


### PR DESCRIPTION
Deprecated lsp--client-get-root was removed in
emacs-lsp/lsp-mode@1908a59ef6b5e21d75209b8e46e11b857abeec6c.
Replace by comparing lsp workspace root with cquerys root assumption.

Fixes #66.